### PR TITLE
Rework value

### DIFF
--- a/src/tree-walker/Builtins.cpp
+++ b/src/tree-walker/Builtins.cpp
@@ -27,7 +27,7 @@ Value builtin_rand(std::span<Value> /* args */) {
 Value builtin_randint(std::span<Value> args) {
     thread_local std::mt19937 engine{};
     if (!holds<double>(args[0]) || !holds<double>(args[1])) {
-        return nullptr;
+        return {};
     }
     const auto min = static_cast<long long>(std::get<double>(args[0]));
     const auto max = static_cast<long long>(std::get<double>(args[1]));

--- a/src/tree-walker/Builtins.cpp
+++ b/src/tree-walker/Builtins.cpp
@@ -26,13 +26,13 @@ Value builtin_rand(std::span<Value> /* args */) {
 
 Value builtin_randint(std::span<Value> args) {
     thread_local std::mt19937 engine{};
-    if (!holds<double>(args[0]) || !holds<double>(args[1])) {
+    if (!args[0].is<Number>() || !args[1].is<Number>()) {
         return {};
     }
-    const auto min = static_cast<long long>(std::get<double>(args[0]));
-    const auto max = static_cast<long long>(std::get<double>(args[1]));
+    const auto min = static_cast<long long>(args[0].as<Number>());
+    const auto max = static_cast<long long>(args[1].as<Number>());
     std::uniform_int_distribution<long long int> dist{ min, max };
-    return static_cast<double>(dist(engine));
+    return static_cast<Number>(dist(engine));
 }
 
 

--- a/src/tree-walker/Environment.cpp
+++ b/src/tree-walker/Environment.cpp
@@ -13,7 +13,7 @@ Environment::Environment(Environment* enclosing, boost::unordered_map<std::strin
 // Retruns a handle to the new element
 ValueHandle Environment::define(const std::string& name, Value value) {
     auto [it, was_inserted] = map_.insert_or_assign(name, std::move(value));
-    return { it->second };
+    return ValueHandle{ it->second };
 }
 
 
@@ -24,7 +24,7 @@ ValueHandle Environment::define(const std::string& name, Value value) {
 ValueHandle Environment::get(const std::string& name) {
     if (map_.contains(name)) {
         // ValueHandle(Value&) **From ref**
-        return map_[name];
+        return ValueHandle{ map_[name] };
     } else if (enclosing_) {
         // ValueHandle(const ValueHandle&) **Copy**
         return enclosing_->get(name);
@@ -37,7 +37,7 @@ ValueHandle Environment::get(const std::string& name) {
 ValueHandle Environment::assign(const std::string& name, Value value) {
     if (map_.contains(name)) {
         map_[name] = std::move(value);
-        return map_[name]; // From ref
+        return ValueHandle{ map_[name] }; // From ref
     } else if (enclosing_) {
         return enclosing_->assign(name, std::move(value)); // Copy
     } else {
@@ -49,7 +49,7 @@ ValueHandle Environment::assign(const std::string& name, Value value) {
 ValueHandle Environment::get_at(size_t distance, const std::string& name) {
     assert(ancestor(distance));
     assert(ancestor(distance)->map_.contains(name));
-    return ancestor(distance)->map_[name]; // From ref
+    return ValueHandle{ ancestor(distance)->map_[name] }; // From ref
 }
 
 
@@ -58,5 +58,5 @@ ValueHandle Environment::assign_at(size_t distance, const std::string& name, Val
     assert(ancestor(distance)->map_.contains(name));
     Value& value_ref = ancestor(distance)->map_[name];
     value_ref = std::move(value);
-    return value_ref; // From ref
+    return ValueHandle{ value_ref }; // From ref
 }

--- a/src/tree-walker/ExprInterpreterVisitor.cpp
+++ b/src/tree-walker/ExprInterpreterVisitor.cpp
@@ -29,7 +29,7 @@ ExprInterpreterVisitor::evaluate_without_decay(const IExpr& expr) const {
 
 
 bool ExprInterpreterVisitor::is_truthful(const Value& value) {
-    if (holds<std::nullptr_t>(value)) {
+    if (holds<Nil>(value)) {
         return false;
     }
 
@@ -81,7 +81,7 @@ ExprInterpreterVisitor::operator()(const UnaryExpr& expr) const {
             // FIXME: report failure?
             break;
     }
-    return nullptr;
+    return {};
 }
 
 
@@ -137,7 +137,7 @@ ExprInterpreterVisitor::operator()(const BinaryExpr& expr) const {
             break;
     }
 
-    return nullptr;
+    return {};
 }
 
 
@@ -249,7 +249,7 @@ ExprInterpreterVisitor::operator()(const CallExpr& expr) const {
         );
     }
 
-    return { nullptr };
+    return {};
 }
 
 

--- a/src/tree-walker/ExprInterpreterVisitor.hpp
+++ b/src/tree-walker/ExprInterpreterVisitor.hpp
@@ -45,7 +45,7 @@ protected:
 
     template<typename T>
     void check_type(const IExpr& expr, const Value& val) const {
-        if (!holds<T>(val)) {
+        if (!val.is<T>()) {
             report_error_and_abort(
                 InterpreterError::unexpected_type, expr,
                 fmt::format("Expected {:s}, Encountered {:s}", type_name(Value{T{}}), type_name(val))

--- a/src/tree-walker/FieldName.hpp
+++ b/src/tree-walker/FieldName.hpp
@@ -4,6 +4,8 @@
 #include <utility>
 #include <boost/functional/hash.hpp>
 
+
+// Why this class exists again?
 class FieldName {
 private:
     std::string name_;

--- a/src/tree-walker/LiteralValue.hpp
+++ b/src/tree-walker/LiteralValue.hpp
@@ -9,9 +9,9 @@
 using LiteralValue = std::variant<Nil, String, Number, Boolean>;
 
 struct LiteralToStringVisitor {
-    std::string operator()(const std::string& val) const { return '"' + val + '"'; }
-    std::string operator()(const double& val) const { return std::string(num_to_string(val)); }
-    std::string operator()(const bool& val) const { return { val ? "true" : "false" }; }
+    std::string operator()(const String& val) const { return '"' + val + '"'; }
+    std::string operator()(const Number& val) const { return std::string(num_to_string(val)); }
+    std::string operator()(const Boolean& val) const { return { val ? "true" : "false" }; }
     std::string operator()(const Nil& /* val */) const { return { "nil" }; }
 };
 

--- a/src/tree-walker/LiteralValue.hpp
+++ b/src/tree-walker/LiteralValue.hpp
@@ -3,14 +3,16 @@
 #include <string>
 #include <cstddef>
 #include "Utils.hpp"
+#include "ValueDecl.hpp"
 
-using LiteralValue = std::variant<std::string, double, bool, std::nullptr_t>;
+
+using LiteralValue = std::variant<Nil, String, Number, Boolean>;
 
 struct LiteralToStringVisitor {
     std::string operator()(const std::string& val) const { return '"' + val + '"'; }
     std::string operator()(const double& val) const { return std::string(num_to_string(val)); }
     std::string operator()(const bool& val) const { return { val ? "true" : "false" }; }
-    std::string operator()(const std::nullptr_t& val) const { return { "nil" }; }
+    std::string operator()(const Nil& /* val */) const { return { "nil" }; }
 };
 
 inline std::string to_string(const LiteralValue& literal) {

--- a/src/tree-walker/Parser.hpp
+++ b/src/tree-walker/Parser.hpp
@@ -174,7 +174,7 @@ private:
             init = expression();
         } else {
             init = std::make_unique<LiteralExpr>(
-                Token{TokenType::kw_nil, "nil", state_.current()->line, nullptr}
+                Token{TokenType::kw_nil, "nil", state_.current()->line, Nil{}}
             );
         }
 
@@ -271,7 +271,7 @@ private:
             value = expression();
         } else {
             value = std::make_unique<LiteralExpr>(
-                Token{ TokenType::kw_nil, "nil", state_.current()->line, nullptr }
+                Token{ TokenType::kw_nil, "nil", state_.current()->line, Nil{} }
             );
         }
 

--- a/src/tree-walker/Scanner.hpp
+++ b/src/tree-walker/Scanner.hpp
@@ -257,7 +257,7 @@ private:
             } else if (it->second == TokenType::kw_false) {
                 add_token(it->second, false);
             } else if (it->second == TokenType::kw_nil) {
-                add_token(it->second, nullptr);
+                add_token(it->second, Nil{});
             } else {
                 add_token(it->second);
             }

--- a/src/tree-walker/Value.cpp
+++ b/src/tree-walker/Value.cpp
@@ -51,7 +51,7 @@ Value Function::operator()(const ExprInterpreterVisitor& interpret_visitor, std:
         return std::move(v);
     }
 
-    return { nullptr };
+    return {};
 }
 
 

--- a/src/tree-walker/Value.cpp
+++ b/src/tree-walker/Value.cpp
@@ -13,7 +13,7 @@
 
 ValueHandle::ValueHandle(Value& target) noexcept : handle_{ &target } {
     assert(
-        !holds<ValueHandle>(target) &&
+        !target.is<ValueHandle>() &&
         "Handle to a Handle is redundant"
     );
 }
@@ -69,7 +69,7 @@ namespace detail {
 
 std::string ValueToStringVisitor::operator()(const ValueHandle& val) const {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): Find me a better way, yeah
-    return fmt::format("?ValueHandle {:x}?", reinterpret_cast<uintptr_t>(val.pointer()));
+    return fmt::format("?ValueHandle 0x{:x}?", reinterpret_cast<uintptr_t>(val.pointer()));
 }
 
 std::string ValueToStringVisitor::operator()(const Function& val) const {

--- a/src/tree-walker/Value.hpp
+++ b/src/tree-walker/Value.hpp
@@ -50,7 +50,7 @@ struct ValueTypeNameVisitor {
     std::string_view operator()(const bool&) const {
         return "Boolean";
     }
-    std::string_view operator()(const std::nullptr_t&) const {
+    std::string_view operator()(const Nil&) const {
         return "Nil";
     }
 };
@@ -71,7 +71,7 @@ struct ValueToStringVisitor {
     std::string operator()(const bool& val) const {
         return { val ? "true" : "false" };
     }
-    std::string operator()(const std::nullptr_t& /* val */) const {
+    std::string operator()(const Nil& /* val */) const {
         return { "nil" };
     }
 };

--- a/src/tree-walker/ValueDecl.hpp
+++ b/src/tree-walker/ValueDecl.hpp
@@ -12,14 +12,29 @@
 // Use this declaration instead.
 
 
+using Nil = std::monostate;
 using String = std::string;
 using Number = double;
 using Boolean = bool;
-using Nil = std::monostate;
 
 class Object;
 class Function;
 class BuiltinFunction;
 class ValueHandle;
 
-using Value = std::variant<Nil, ValueHandle, Object, Function, BuiltinFunction, String, Number, Boolean>;
+using ValueVariant = std::variant<Nil, ValueHandle, Object, Function, BuiltinFunction, String, Number, Boolean>;
+
+class Value;
+
+// A user-friendly alternative to variant::index().
+// Probably don't do 'using enum ValueType;'.
+enum class ValueType : size_t {
+    Nil = 0,
+    ValueHandle,
+    Object,
+    Function,
+    BuiltinFunction,
+    String,
+    Number,
+    Boolean
+};

--- a/src/tree-walker/ValueDecl.hpp
+++ b/src/tree-walker/ValueDecl.hpp
@@ -12,10 +12,14 @@
 // Use this declaration instead.
 
 
+using String = std::string;
+using Number = double;
+using Boolean = bool;
+using Nil = std::nullptr_t; // Could be std::monostate
+
 class Object;
 class Function;
-class Environment;
 class BuiltinFunction;
 class ValueHandle;
 
-using Value = std::variant<ValueHandle, Object, Function, BuiltinFunction, std::string, double, bool, std::nullptr_t>;
+using Value = std::variant<Nil, ValueHandle, Object, Function, BuiltinFunction, String, Number, Boolean>;

--- a/src/tree-walker/ValueDecl.hpp
+++ b/src/tree-walker/ValueDecl.hpp
@@ -3,24 +3,15 @@
 #include <string>
 #include <cstddef>
 
-
-// Since 'Value' is not a class, but an alias,
-// we cannot predeclare it as incomplete type:
-//
-// class Value; // not allowed
-//
-// Use this declaration instead.
-
-
 using Nil = std::monostate;
+class Object;
+class ValueHandle;
+class Function;
+class BuiltinFunction;
 using String = std::string;
 using Number = double;
 using Boolean = bool;
 
-class Object;
-class Function;
-class BuiltinFunction;
-class ValueHandle;
 
 using ValueVariant = std::variant<Nil, ValueHandle, Object, Function, BuiltinFunction, String, Number, Boolean>;
 

--- a/src/tree-walker/ValueDecl.hpp
+++ b/src/tree-walker/ValueDecl.hpp
@@ -15,7 +15,7 @@
 using String = std::string;
 using Number = double;
 using Boolean = bool;
-using Nil = std::nullptr_t; // Could be std::monostate
+using Nil = std::monostate;
 
 class Object;
 class Function;


### PR DESCRIPTION
Changes Value from variant alias to a variant wrapper class, and introduces much more readable ways of inspecting/unpacking the variant:

```C++
// Before:
std::holds_alternative<Number>(value);
std::get<Number>(value);

// After:
value.is<Number>();
value.as<Number>();
```

Also makes the `ValueHandle(Value&)` constructor explicit, as that was a terrible mistake.